### PR TITLE
Make source file option optional

### DIFF
--- a/riscv-compiler.py
+++ b/riscv-compiler.py
@@ -30,7 +30,7 @@ def main():
             action='store',
             nargs='+',
             help='Path of source code to be compiled',
-            required=True)
+            required=False)
     parser.add_argument('-o', '--output',
             action='store',
             help='Path to output executable file, default is /tmp/riscv.out',
@@ -44,7 +44,15 @@ def main():
         parser.error("Invalid Options.")
         sys.exit(1)
 
-    fileNames = args.source_file
+    fileNames = []
+    for option in compilerOptions:
+        if not option.startswith('-'):
+            compilerOptions.remove(option)
+            fileNames.append(option)
+
+    if args.source_file:
+        fileNames = args.source_file
+
     containerName = args.toolchain_container
     exeContainerName = args.execution_container
 

--- a/run.md
+++ b/run.md
@@ -21,6 +21,6 @@ python3 envsetup --llvm -mp /home/opt/docker_home --setup_exe
 Use https://github.com/hiraditya/Toolchains/blob/master/riscv-compiler.py
 
 ```sh
-python3 riscv-compiler.py --toolchain-container docker1 --execution-container docker2 --source-file file.c file1.c file2.c -o riscv.out -O3
+python3 riscv-compiler.py --toolchain-container docker1 --execution-container docker2  file.c file1.c file2.c -o riscv.out -O3
 ```
 


### PR DESCRIPTION
Now you can directly provide the source file to the compiler wrapper script instead of using --source-file flag 